### PR TITLE
Trailing spatial dims for spectral conv layers

### DIFF
--- a/models/func_to_vec2d.py
+++ b/models/func_to_vec2d.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .shared import SpectralConv2d, LinearFunctionals2d, get_grid2d
+from .shared import SpectralConv2d, LinearFunctionals2d, get_grid2d, _get_act, MLP
 
 
 class FNF2d(nn.Module):
@@ -17,7 +17,8 @@ class FNF2d(nn.Module):
                  padding=8,
                  d_in=2, # TODO: adjust default to 1, check this does not break train scripts
                  d_out=1,
-                 width_lfunc=None
+                 width_lfunc=None,
+                 act='gelu'
                  ):
         """
         modes1, modes2  (int): Fourier mode truncation levels
@@ -27,6 +28,7 @@ class FNF2d(nn.Module):
         d_in            (int): number of input channels (NOT including grid input features)
         d_out           (int): finite number of desired outputs (number of functionals)
         width_lfunc     (int): number of intermediate linear functionals to extract in FNF layer
+        act             (str): Activation function = tanh, relu, gelu, elu, or leakyrelu
         """
         super(FNF2d, self).__init__()
 
@@ -42,6 +44,7 @@ class FNF2d(nn.Module):
             self.width_lfunc = self.width
         else:
             self.width_lfunc = width_lfunc
+        self.act = _get_act(act)
         
         self.fc0 = nn.Linear(self.d_in + self.d_physical, self.width)
 
@@ -55,8 +58,7 @@ class FNF2d(nn.Module):
         
         self.lfunc0 = LinearFunctionals2d(self.width, self.width_lfunc, self.modes1, self.modes2)
 
-        self.fc1 = nn.Linear(self.width_lfunc, self.width_final)
-        self.fc2 = nn.Linear(self.width_final, self.d_out)
+        self.mlp0 = MLP(self.width_lfunc, self.width_final, self.d_out, act)
 
     def forward(self, x):
         """
@@ -76,20 +78,18 @@ class FNF2d(nn.Module):
 
         # Fourier integral operator layers on the torus
         x = self.w0(x) + self.conv0(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         x = self.w1(x) + self.conv1(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         x = self.w2(x) + self.conv2(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         # Extract Fourier neural functionals on the torus
         x = self.lfunc0(x)
         
         # Final projection layer
-        x = self.fc1(x)
-        x = F.gelu(x)
-        x = self.fc2(x)
+        x = self.mlp0(x)
 
         return x

--- a/models/vec_to_func1d.py
+++ b/models/vec_to_func1d.py
@@ -1,8 +1,6 @@
-import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-from .shared import SpectralConv1d, LinearDecoder1d
+from .shared import SpectralConv1d, LinearDecoder1d, _get_act, MLP
 
 
 class FND1d(nn.Module):
@@ -16,7 +14,8 @@ class FND1d(nn.Module):
                  width_final=128,
                  padding=8,
                  d_out=1,
-                 width_ldec=None
+                 width_ldec=None,
+                 act='gelu'
                  ):
         """
         d_in            (int): number of input channels (dimension of input vectors)
@@ -28,6 +27,7 @@ class FND1d(nn.Module):
         padding         (int or float): (1.0/padding) is fraction of domain to zero pad (non-periodic)
         d_out           (int): finite number of desired outputs (number of functions)
         width_ldec      (int): input channel width for FND layer
+        act             (str): Activation function = tanh, relu, gelu, elu, or leakyrelu
         """
         super(FND1d, self).__init__()
 
@@ -42,11 +42,11 @@ class FND1d(nn.Module):
             self.width_ldec = self.width
         else:
             self.width_ldec = width_ldec
+        self.act = _get_act(act)
             
         self.set_outputspace_resolution(s_outputspace)
         
-        self.fc0 = nn.Linear(self.d_in, self.width_initial)
-        self.fc1 = nn.Linear(self.width_initial, self.width_ldec)
+        self.mlp0 = MLP(self.d_in, self.width_initial, self.width_ldec, act)
         
         self.ldec0 = LinearDecoder1d(self.width_ldec, self.width, self.modes1)
         
@@ -58,8 +58,7 @@ class FND1d(nn.Module):
         self.w1 = nn.Conv1d(self.width, self.width, 1)
         self.w2 = nn.Conv1d(self.width, self.width, 1)
         
-        self.fc2 = nn.Linear(self.width, self.width_final)
-        self.fc3 = nn.Linear(self.width_final, self.d_out)
+        self.mlp1 = MLP(self.width, self.width_final, self.d_out, act)
 
     def forward(self, x):
         """
@@ -69,19 +68,17 @@ class FND1d(nn.Module):
         The output resolution is determined by self.s_outputspace
         """
         # Nonlinear processing layer
-        x = self.fc0(x)
-        x = F.gelu(x)
-        x = self.fc1(x)
+        x = self.mlp0(x)
         
         # Decode into functions on the torus
         x = self.ldec0(x, self.s_outputspace)
 
         # Fourier integral operator layers on the torus
         x = self.w0(x) + self.conv0(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         x = self.w1(x) + self.conv1(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         x = self.w2(x) + self.conv2(x)
            
@@ -90,9 +87,7 @@ class FND1d(nn.Module):
  
         # Final projection layer
         x = x.permute(0, 2, 1)
-        x = self.fc2(x)
-        x = F.gelu(x)
-        x = self.fc3(x)
+        x = self.mlp1(x)
            
         return x.permute(0, 2, 1)
     

--- a/models/vec_to_vec1d.py
+++ b/models/vec_to_vec1d.py
@@ -1,8 +1,6 @@
-import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-from .shared import SpectralConv1d, LinearDecoder1d, LinearFunctionals1d
+from .shared import SpectralConv1d, LinearDecoder1d, LinearFunctionals1d, _get_act, MLP
 
 
 class FNN1d(nn.Module):
@@ -16,7 +14,8 @@ class FNN1d(nn.Module):
                  width_initial=128,
                  width_final=128,
                  width_ldec=None,
-                 width_lfunc=None
+                 width_lfunc=None,
+                 act='gelu'
                  ):
         """
         d_in            (int): number of input channels (dimension of input vectors)
@@ -28,6 +27,7 @@ class FNN1d(nn.Module):
         width_final     (int): width of the final projection layer
         width_ldec      (int): input channel width for FND layer
         width_lfunc     (int): number of intermediate linear functionals to extract in FNF layer
+        act             (str): Activation function = tanh, relu, gelu, elu, or leakyrelu
         """
         super(FNN1d, self).__init__()
 
@@ -46,9 +46,9 @@ class FNN1d(nn.Module):
             self.width_lfunc = self.width
         else:
             self.width_lfunc = width_lfunc
+        self.act = _get_act(act)
         
-        self.fc0 = nn.Linear(self.d_in, self.width_initial)
-        self.fc1 = nn.Linear(self.width_initial, self.width_ldec)
+        self.mlp0 = MLP(self.d_in, self.width_initial, self.width_ldec, act)
         
         self.ldec0 = LinearDecoder1d(self.width_ldec, self.width, self.modes1)
         
@@ -60,8 +60,7 @@ class FNN1d(nn.Module):
         
         self.lfunc0 = LinearFunctionals1d(self.width, self.width_lfunc, self.modes1)
         
-        self.fc2 = nn.Linear(self.width_lfunc, self.width_final)
-        self.fc3 = nn.Linear(self.width_final, self.d_out)
+        self.mlp1 = MLP(self.width_lfunc, self.width_final, self.d_out, act)
 
     def forward(self, x):
         """
@@ -69,27 +68,23 @@ class FNN1d(nn.Module):
         Output shape:           (batch, self.d_out)
         """
         # Nonlinear processing layer
-        x = self.fc0(x)
-        x = F.gelu(x)
-        x = self.fc1(x)
+        x = self.mlp0(x)
         
         # Decode into functions on the torus
         x = self.ldec0(x, self.s_latentspace)
 
         # Fourier integral operator layers on the torus
         x = self.w0(x) + self.conv0(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         x = self.w1(x) + self.conv1(x)
-        x = F.gelu(x)
+        x = self.act(x)
 
         # Extract Fourier neural functionals on the torus
         x = self.lfunc0(x)
         
         # Final projection layer
-        x = self.fc2(x)
-        x = F.gelu(x)
-        x = self.fc3(x)
+        x = self.mlp1(x)
 
         return x
     


### PR DESCRIPTION
# In this PR
- [x] Allows the function-to-function Fourier layers to take as input functions of d>1 or d>2 variables. In this case, the discrete Fourier transforms are only applied to the last dimensions of the input and the extra spatial dimensions are broadcasted.
- [x] Checked that the indexing is correct (layers output the correct shape)
- [x] Also added ShallowNN MLP layer module to improve readability of models (see [here](https://github.com/neural-operator/fourier_neural_operator/blob/af93f781d5e013f8ba5c52baa547f2ada304ffb0/fourier_2d.py#L54))
- [x] added activation as optional argument into models